### PR TITLE
Fix picture colors in Infocom's V6 games

### DIFF
--- a/Win/FrotzCore.cpp
+++ b/Win/FrotzCore.cpp
@@ -937,7 +937,7 @@ extern "C" void os_scroll_area(int top, int left, int bottom, int right, int uni
   theWnd->FlushText();
   theWnd->ResetOverhang();
 
-  theWnd->Scroll(left-1,top-1,right-left+1,bottom-top+1,units);
+  theWnd->Scroll(CRect(left-1,top-1,right,bottom),units);
   if (units > 0)
     theWnd->FillBackground(CRect(left-1,bottom-units,right,bottom));
   else
@@ -1224,9 +1224,9 @@ extern "C" int os_picture_data(int picture, int *height, int *width)
       FrotzGfx* gfx = FrotzGfx::Get(picture,theApp.GetBlorbMap(),false);
       if (gfx != NULL)
       {
-        double r = gfx->CalcScalingRatio(theWnd->CalcScalingERF());
-        *height = gfx->GetHeight(r);
-        *width = gfx->GetWidth(r);
+        CSize size = theWnd->GetGraphicSize(gfx);
+        *height = size.cy;
+        *width = size.cx;
         return 1;
       }
     }
@@ -1251,10 +1251,8 @@ extern "C" void os_draw_picture(int picture, int y, int x)
     FrotzGfx* gfx = FrotzGfx::Get(picture,theApp.GetBlorbMap(),false);
     if (gfx != NULL)
     {
-      signed short x1 = (signed short)x;
-      signed short y1 = (signed short)y;
-      double r = gfx->CalcScalingRatio(theWnd->CalcScalingERF());
-      theWnd->DrawGraphic(gfx,x1-1,y1-1,r);
+      CPoint point((short)x-1,(short)y-1);
+      theWnd->DrawGraphic(gfx,point);
     }
   }
 }

--- a/Win/FrotzDialogs.cpp
+++ b/Win/FrotzDialogs.cpp
@@ -156,30 +156,26 @@ BOOL AboutGameDialog::OnInitDialog()
   if (gameInfo.cover != -1)
     coverGfx = FrotzGfx::Get(gameInfo.cover,theApp.GetBlorbMap(),gameInfo.coverFormatWrong);
 
-  // Choose a size for the cover art
   CRect screen = theApp.GetScreenSize(true);
   if (coverGfx != NULL)
   {
-    double aspect = (double)coverGfx->GetWidth(1.0) / (double)coverGfx->GetHeight(1.0);
-    int coverX = screen.Width()/3;
-    int coverY = (int)(coverX / aspect);
-    m_coverRect = CRect(initRect.TopLeft(),CSize(coverX,coverY));
+    // Choose a size for the cover art
+    CSize size = coverGfx->GetSize(1.0);
+
+    double r = (double) screen.Width() / ((double) size.cx * 3.0);
+
+    size = coverGfx->GetSize(r);
+
+    // Resize the cover art
+    CWindowDC dc(this);
+    if (!m_coverBitmap.CreateBitmap(dc,size.cx,size.cy))
+      return FALSE;
+    coverGfx->Paint(m_coverBitmap,CPoint(0,0),r);
+
+    m_coverRect = CRect(initRect.TopLeft(),size);
   }
   else
     m_coverRect = CRect(initRect.TopLeft(),CSize(screen.Width()/3,screen.Width()/3));
-  m_coverRect.top = (int)(initRect.top*0.6);
-
-  // Resize the cover art
-  if (coverGfx != NULL)
-  {
-    CDC* dc = GetDC();
-    BOOL create = m_coverBitmap.CreateBitmap(dc->GetSafeHdc(),
-      m_coverRect.Width(),m_coverRect.Height());
-    ReleaseDC(dc);
-    if (!create)
-      return FALSE;
-    coverGfx->Paint(m_coverBitmap);
-  }
 
   // Resize the rich edit control
   CRect infoRect = m_coverRect;

--- a/Win/FrotzGfx.h
+++ b/Win/FrotzGfx.h
@@ -15,19 +15,14 @@ extern "C"
 class FrotzGfx
 {
 public:
-  FrotzGfx();
-  ~FrotzGfx();
-
-  // Get the width of the picture
-  int GetWidth(double r);
-  // Get the height of the picture
-  int GetHeight(double r);
-  // Calculate the scaling ratio for this picture
-  double CalcScalingRatio(double erf);
+  // Get the size of the picture
+  CSize GetSize(double erf);
   // Draw the picture
-  void Paint(CDibSection& dib);
-  void Paint(CDibSection& dib, int x, int y);
-  void Paint(CDibSection& dib, CDC& dc, int x, int y, double r);
+  void Paint(CDibSection& dib, CPoint point, double erf);
+  // Apply the picture's palette to the screen palette
+  bool ApplyPalette();
+  // Does this picture need to be redrawn after screen palette changes?
+  bool IsColorChanger();
 
   // Get a picture from the cache or the Blorb resource map
   static FrotzGfx* Get(int picture, bb_map_t* map, bool permissive);
@@ -39,25 +34,29 @@ public:
   static void SetGamma(double gamma);
 
 protected:
+  FrotzGfx();
+  ~FrotzGfx();
+
   static FrotzGfx* LoadPNG(BYTE* data, int length);
   static FrotzGfx* LoadJPEG(BYTE* data, int length);
   static FrotzGfx* LoadRect(BYTE* data, int length);
-  FrotzGfx* CreateScaled(double r);
 
 protected:
   BYTE* m_pixels;
-  BITMAPINFOHEADER *m_header;
 
   int m_width;
   int m_height;
+
+  int m_transparentColor;
 
   double m_ratioStd;
   double m_ratioMin;
   double m_ratioMax;
 
-  bool m_adapt;
   CArray<DWORD,DWORD> m_palette;
-  CMap<DWORD,DWORD,int,int> m_invPalette;
+
+  bool m_usesPalette;
+  bool m_colorChanger;
 
   static double m_gamma;
   static int m_toLinear[256];
@@ -65,5 +64,6 @@ protected:
 
   static CMap<int,int,FrotzGfx*,FrotzGfx*> m_cache;
   static CMap<int,int,int,int> m_adaptive;
-  static CArray<DWORD,DWORD> m_currentPalette;
+  static bool m_adaptiveMode;
+  static DWORD m_screenPalette[16];
 };

--- a/Win/FrotzWnd.h
+++ b/Win/FrotzWnd.h
@@ -162,13 +162,15 @@ public:
   void SetTextPoint(POINT point);
 
   // Scroll the bitmap
-  void Scroll(int left, int top, int width, int height, int units);
+  void Scroll(LPCRECT rect, int units);
   // Fill a rectangle with the background colour
   void FillBackground(LPCRECT rect);
   // Fill a rectangle with the given colour
   void FillSolid(LPCRECT rect, COLORREF colour);
   // Draw a bitmap graphic
-  void DrawGraphic(FrotzGfx* gfx, int x, int y, double r);
+  void DrawGraphic(FrotzGfx* gfx, CPoint point);
+  // Get the size of the bitmap graphic after scaling
+  CSize GetGraphicSize(FrotzGfx* gfx);
   // Get the colour of a pixel
   COLORREF GetPixel(POINT p);
 
@@ -209,8 +211,6 @@ public:
   void SetAllowResize(bool allow);
   // Resize the display and redraw
   void ResizeDisplay(void);
-  // Calculate the ERF for scaling pictures
-  double CalcScalingERF(void);
 
   // Wrapper for showing and removing the cursor
   class DrawCursor
@@ -246,6 +246,13 @@ protected:
   void SelectFont(CFont& font);
   // Get the current background colour
   COLORREF GetBackColour(void);
+  // Calculate the ERF for scaling pictures
+  double CalcScalingERF(void);
+
+  // Redraw 'color changer' pictures
+  void RedrawColorChangers(double erf);
+  // Remove 'color changer' pictures contained in the rectangle
+  void PurgeColorChangers(LPCRECT rect);
 
 protected:
   CDC m_dc;
@@ -273,6 +280,8 @@ protected:
   CBitmap m_gfxBitmap;
   CBitmap m_charBitmap;
   CDibSection m_cursorBitmap;
+
+  CMap<FrotzGfx*,FrotzGfx*,CPoint,CPoint> m_mapColorChanger;
 
   TextSettings m_current;
   UnicodeString m_pendingText;


### PR DESCRIPTION
With these changes borders in Arthur and Shogun change colors like they did on the original interpreters. In addition, colors of an ornate initial in Zork Zero have been fixed.

My scheme works as follows:

- Depending on the story ID certain pictures will be marked as 'color changers'. The respective picture numbers have been hard-coded in FrotzGfx::Get().
- FrotzWnd maintains a map (m_mapColorChanger) to keep track of color changer pictures and their current locations.
- Whenever the screen palette changes all pictures in the map are re-drawn.
- When an area of the screen is erased all pictures located in this area are removed from the map.
- The same thing happens when an area is scrolled. (This rule is needed for the initial in Zork Zero.)

To simplify my task I have made a number of changes in FrotzGfx -- most notably, when the Blorb file contains an 'APal' chunk, pictures with a color palette are no longer converted to true color.

