### PR TITLE
Potential for illegal opcode during timeout event

### DIFF
--- a/Generic/stream.c
+++ b/Generic/stream.c
@@ -344,9 +344,19 @@ continue_input:
 
     /* Handle timeouts */
 
-    if (key == ZC_TIME_OUT)
-	if (direct_call (routine) == 0)
-	    goto continue_input;
+    /*
+     * Make sure that this is a real timeout, by checking
+     * that the requested timeout is not zero.  For the case
+     * of a recorded stream, it is possible that a timeout
+     * keystroke might be replayed.
+     */
+    if (key == ZC_TIME_OUT) {
+	if (timeout != 0) {
+	    if (direct_call (routine) == 0)
+		goto continue_input;
+        } else
+            goto continue_input;
+    }
 
     /* Handle hot keys */
 


### PR DESCRIPTION
When a timeout keycode is received, make sure that it is expected, otherwise a non-existent timeout routine may be called.  Then, instead of passing on an timeout event when there is no timeout set, just skip it.

This bug in the core was discovered by @auraes at https://gitlab.com/DavidGriffith/frotz/issues/136 and a fix was presented by @welash.

To tickle the bug, do the following in this game.  After the replay command is finished, you'll see `Fatal error: Illegal opcode` and then a prompt to exit Windows Frotz.

````
recording on
enter
recording off
replay
````

````
Include "parser.h";
Include "verblib.h";

Object room1 "Room 1"
with description "You are in room 1. ^Come in, Room 2 is waiting for you.",
 Before [;
  GoIn:
   print "You are hesitating... ";
   MyKeyDelay(15);
   print "then you decide to enter.^";
   PlayerTo(room2);
   rtrue;
 ], 
has light;

[ MyKeyTimerInterrupt;
    rtrue;
];

[ MyKeyDelay tenths key;
    @read_char 1 tenths MyKeyTimerInterrupt -> key;
    return key;
];

Object room2 "Room 2"
with description "You are in room 2." 
has light;

[ Initialise; location = room1; ];

Include "grammar.h";
````
[replay.z5.gz](https://github.com/DavidKinder/Windows-Frotz/files/3561830/replay.z5.gz)

