### PR TITLE
Add transcript section to Running Infocom help topic

### DIFF
--- a/Win/help/running_infocom.htm
+++ b/Win/help/running_infocom.htm
@@ -54,6 +54,13 @@ the <b>.blb</b> extension) and then simply load the <nobr>Z-code</nobr> game fil
 In addition, the Atari ST version of <b>Beyond Zork</b> came with a title picture. This picture has been converted
 to PNG and packaged into a Blorb file, which is available at the link given above for all the other Blorb files. If
 this Blorb file is present then Windows Frotz will show the title picture when <b>Beyond Zork</b> starts.
+
+<h2><a name="transcript"></a>Interaction Transcript</h2>
+
+Windows Frotz supports writing UTF-8 log files containing all interactions with a game. To enable transcripts enter
+"script" as a command to the game. You will then be prompted for a folder and file name. Note: The setting is
+not persisted by saving the game, so don't forget to start the transcript again when resuming a saved game.
+
  </body>
 </html>
 


### PR DESCRIPTION
I suggest adding a small section about transcripts to the help file, because then you can find it using the search and get more information than just the release notes. As it's kind of game related, the "Running Infocom" help topic seemed to be a good choice.