### PR TITLE
Check OLD_SOUND_FLAG or SOUND_FLAG if V3

### DIFF
--- a/Win/FrotzCore.cpp
+++ b/Win/FrotzCore.cpp
@@ -415,10 +415,12 @@ extern "C" void os_init_screen(void)
   h_screen_rows = (zbyte)screen_rows;
 
   // Check for sound
-  if ((h_version == V3) && (h_flags & OLD_SOUND_FLAG))
+  //if ((h_version == V3) && (h_flags & OLD_SOUND_FLAG)) /* Fix for i6 */
+  if ((h_version == V3) && ((h_flags & OLD_SOUND_FLAG) || (h_flags & SOUND_FLAG)))
   {
     if (!theApp.GotBlorbFile() || !FrotzSound::Init(theWnd))
       h_flags &= ~OLD_SOUND_FLAG;
+      h_flags &= ~SOUND_FLAG; /* For inform6 */
   }
   else if ((h_version >= V4) && (h_flags & SOUND_FLAG))
   {


### PR DESCRIPTION
Check for sound now checks for either `OLD_SOUND_FLAG` or `SOUND_FLAG` if the story version is V3.

Inform 6 sets SOUND_FLAG when compiling to V3. There will soon be an option to set and clear whatever flags you please, but the default will still be SOUND_FLAG. This covers all bases, in much the same way the current build of Frotz handles this.

#40 